### PR TITLE
Being able to pick LavinMQ version

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -8,8 +8,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-20.04, ubuntu-22.04 ]
+        version: [ latest ]
+        include:
+          - { os: ubuntu-24.04, version: '1.3.1' }
 
-    name: ${{ matrix.os }}
+    name: ${{ matrix.os }} (${{ matrix.version }})
     runs-on: ${{ matrix.os }}
     continue-on-error: true # prevent the workflow to fail if this job fails
     steps:
@@ -22,9 +25,15 @@ jobs:
     - run: sudo apt-get update
       shell: bash
       continue-on-error: true
-    - run: sudo apt install lavinmq
+    - name: "Install LavinMQ (${{ matrix.version }})"
+      run: |
+        if test "${{ matrix.version }}" = "latest";
+        then
+          sudo apt-get install lavinmq
+        else
+          sudo apt-get install "lavinmq=${{ matrix.version }}-1"
+        fi
       shell: bash
-      continue-on-error: true
     - run: sudo ls -al /etc/lavinmq
       shell: bash
       continue-on-error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-20.04, ubuntu-22.04 ]
+        version: [ latest ]
+        include:
+          - { os: ubuntu-24.04, version: '1.3.1' }
 
-    name: ${{ matrix.os }}
+    name: ${{ matrix.os }} (${{ matrix.version }})
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
     - uses: ./
+      with:
+        version: ${{ matrix.version }}
     - run: lavinmq --version
     - run: systemctl is-active lavinmq.service
     - run: echo $AMQP_URL

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: "Name of the environment variable with the LavinMQ URL"
     required: false
     default: "AMQP_URL"
+  version:
+    description: "The version of LavinMQ to install"
+    required: false
+    default: "latest"
 runs:
   using: "composite"
   steps:
@@ -20,7 +24,14 @@ runs:
     - run: sudo apt-get update
       shell: bash
 
-    - run: sudo apt install lavinmq
+    - name: "Install LavinMQ (${{ inputs.version }})"
+      run: |
+        if test "${{ inputs.version }}" = "latest";
+        then
+          sudo apt-get install lavinmq
+        else
+          sudo apt-get install "lavinmq=${{ inputs.version }}-1"
+        fi
       shell: bash
 
     - run: sudo systemctl start lavinmq.service


### PR DESCRIPTION
Useful right now as there is no compatible package for Ubuntu 24.04, but could probably be handy in more situations.

Switched from`apt ...` to `apt-get ...` to avoid the warning `WARNING: apt does not have a stable CLI interface. Use with caution in scripts.`.