### PR TITLE
Speed up installation, skip building man pages

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,12 @@ runs:
     - run: echo "deb https://packagecloud.io/cloudamqp/lavinmq/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/lavinmq.list
       shell: bash
 
+    - name: Configure dpkg to skip building man pages
+      run: |
+        echo 'path-exclude /usr/share/doc/*' | sudo tee -a /etc/dpkg/dpkg.cfg.d/01_nodoc
+        echo 'path-exclude /usr/share/man/*' | sudo tee -a /etc/dpkg/dpkg.cfg.d/01_nodoc
+      shell: bash
+
     - run: sudo apt-get update
       shell: bash
 


### PR DESCRIPTION
[Before](https://github.com/cloudamqp/lavinmq-action/actions/runs/16235104840/job/45844151182#step:3:112) it took ~1 minute

```
Sat, 12 Jul 2025 06:08:21 GMT Processing triggers for man-db (2.12.0-4build2) ...
Sat, 12 Jul 2025 06:09:28 GMT Running kernel seems to be up-to-date.
```

[Now](https://github.com/cloudamqp/lavinmq-action/actions/runs/17275339782/job/49030523091#step:3:127) it takes ~1 second

```
Wed, 27 Aug 2025 18:26:51 GMT Processing triggers for man-db (2.12.0-4build2) ...
Wed, 27 Aug 2025 18:26:52 GMT Running kernel seems to be up-to-date.